### PR TITLE
Add --diff option to test_one and test_all

### DIFF
--- a/bin/mesa_test
+++ b/bin/mesa_test
@@ -28,8 +28,8 @@ class MesaTest < Thor
   #{MesaTestCase.modules.map { |mod| '    ' + mod.to_s }.join(', ')}
 
   With --diff option, assume the checksums are up-to-date (behave like
-  each_test_run_and_diff).  Otherwise, update checksums after ./rn
-  (behave like each_test_run).
+  each_test_run_and_diff), on by default.  To update checksums after ./rn
+  (behave like each_test_run), use --no-diff.
 
   With --force option, skip confirmation of computer details, assuming values
   in ~/.mesa_test.yml are correct.
@@ -43,7 +43,7 @@ class MesaTest < Thor
   With --submit option, upload results to MESATestHub. By default, this is on.
   To run without submission, use --no-submit.
   LONGDESC
-  option :diff, type: :boolean, aliases: '-d'
+  option :diff, type: :boolean, default: true
   option :force, type: :boolean, aliases: '-f'
   option :log, type: :boolean, default: true
   option :module, type: :string, default: :all
@@ -106,8 +106,8 @@ class MesaTest < Thor
   detailed in MESA_DIR/star/test_suite/do1_test_source.
 
   With --diff option, assume the checksums are up-to-date (behave like
-  each_test_run_and_diff).  Otherwise, update checksums after ./rn
-  (behave like each_test_run).
+  each_test_run_and_diff), on by default.  To update checksums after ./rn
+  (behave like each_test_run), use --no-diff.
 
   With --force option, skip confirmation of computer details, assuming values
   in ~/.mesa_test.yml are correct. Only relevant if --submit option is on
@@ -119,7 +119,7 @@ class MesaTest < Thor
   With --submit option, upload results to MESATestHub. By default, this is on.
   To run without submission, use --no-submit.
   LONGDESC
-  option :diff, type: :boolean, aliases: '-d'
+  option :diff, type: :boolean, default: true
   option :force, type: :boolean, aliases: '-f'
   option :log, type: :boolean, default: true
   option :submit, type: :boolean, default: true

--- a/bin/mesa_test
+++ b/bin/mesa_test
@@ -27,6 +27,10 @@ class MesaTest < Thor
 
   #{MesaTestCase.modules.map { |mod| '    ' + mod.to_s }.join(', ')}
 
+  With --diff option, assume the checksums are up-to-date (behave like
+  each_test_run_and_diff).  Otherwise, update checksums after ./rn
+  (behave like each_test_run).
+
   With --force option, skip confirmation of computer details, assuming values
   in ~/.mesa_test.yml are correct.
 
@@ -39,6 +43,7 @@ class MesaTest < Thor
   With --submit option, upload results to MESATestHub. By default, this is on.
   To run without submission, use --no-submit.
   LONGDESC
+  option :diff, type: :boolean, aliases: '-d'
   option :force, type: :boolean, aliases: '-f'
   option :log, type: :boolean, default: true
   option :module, type: :string, default: :all
@@ -61,6 +66,9 @@ class MesaTest < Thor
       "install a valid MESA version or provide the path to one." unless
       m.installed?
     m.load_test_source_data
+
+    # choose whether to update checksums
+    m.update_checksums = !options[:diff]
 
     # make sure the test case is valid
     t = m.find_test_case(test_case_name: test_case_name,
@@ -97,6 +105,10 @@ class MesaTest < Thor
   report results to MesaTestHub. Specifically, runs and checks all tests
   detailed in MESA_DIR/star/test_suite/do1_test_source.
 
+  With --diff option, assume the checksums are up-to-date (behave like
+  each_test_run_and_diff).  Otherwise, update checksums after ./rn
+  (behave like each_test_run).
+
   With --force option, skip confirmation of computer details, assuming values
   in ~/.mesa_test.yml are correct. Only relevant if --submit option is on
   (by default it is).
@@ -107,6 +119,7 @@ class MesaTest < Thor
   With --submit option, upload results to MESATestHub. By default, this is on.
   To run without submission, use --no-submit.
   LONGDESC
+  option :diff, type: :boolean, aliases: '-d'
   option :force, type: :boolean, aliases: '-f'
   option :log, type: :boolean, default: true
   option :submit, type: :boolean, default: true
@@ -132,6 +145,7 @@ class MesaTest < Thor
     m.load_test_source_data
 
     # run all tests
+    m.update_checksums = !options[:diff]
     m.each_test_run_and_diff(log_results: options[:log])
 
     # submit all tests


### PR DESCRIPTION
There are two main MESA testing scripts: each_test_run and
each_test_run_and_diff.

Checksum files (checks.md5) are used to confirm that results are
bit-for-bit identical.

each_test_run does not assume these checksums are up-to-date.  Thus it
generates them when doing ./rn and then checks against them when doing
./re.

each_test_run_and_diff does assume that these checks are up-to-date
and checks against them when doing ./rn and ./re.

Before a release, someone does ./each_test_run and confirms things are
working.  Then they commit the updated checksums and folks go forth
and do ./each_test_run_and_diff on many different machines to confirm
that everyone is getting the same results.

However, during development, the checksums are not kept up-to-date.

This changes mesa_test to emulate each_test_run by default.  If the
--diff argument is given, it emulates each_test_run_and_diff.

The goal is to prevent a lot of (noisy) failures that are only because
the checksums aren't up-to-date and not because MESA has a problem.