### PR TITLE
Support cases where global bit-for-bit agreement is not required

### DIFF
--- a/lib/mesa_test.rb
+++ b/lib/mesa_test.rb
@@ -1271,7 +1271,14 @@ class MesaTestCase
     # this should ONLY be read after we are certain we've passed AND that we
     # even have a newly-made checksum
     if File.exist?('checks.md5') && @mesa.update_checksums
-      @checksum = File.read('checks.md5').split.first
+      # sometimes we want to ignore the final checksum value
+      # we still want to check that restarts on individual machines are bit-for-bit
+      # but we don't require bit-for-bit globally, so we report a bogus checksum
+      if File.exist?('.ignore_checksum') then
+        @checksum ='00000000000000000000000000000000'
+      else
+        @checksum = File.read('checks.md5').split.first
+      end
     end
     write_success_msg(success_type)
     true


### PR DESCRIPTION
Motivated by Bill's rsp cases, this reports a checksum of all zeros to
the TestHub when the file .ignore_checksum exists in a test case.

Since ./ck remains unmodified, the test that the checksums are
reproduced on an individual machine after a restart should remain
intact.